### PR TITLE
Add audio input notifier.

### DIFF
--- a/declarations/gnomejs.d.ts
+++ b/declarations/gnomejs.d.ts
@@ -10,6 +10,9 @@ declare module "gnomejs://main.js" {
     _deviceItems: Map<number, DeviceItem>;
     _removeDevice: (id: number) => void;
     _addDevice: (id: number) => void;
+    connect: (text: string, cb: () => void) => number;
+    disconnect: (id: number) => void;
+    visible: boolean;
   };
 
   export const panel: {

--- a/resources/schemas/org.gnome.shell.extensions.do-not-disturb-while-screen-sharing-or-recording.gschema.xml
+++ b/resources/schemas/org.gnome.shell.extensions.do-not-disturb-while-screen-sharing-or-recording.gschema.xml
@@ -3,6 +3,10 @@
   <schema id="org.gnome.shell.extensions.do-not-disturb-while-screen-sharing-or-recording" 
           path="/org/gnome/shell/extensions/do-not-disturb-while-screen-sharing-or-recording/">
     <!-- See also: https://docs.gtk.org/glib/gvariant-format-strings.html -->
+    <key name="dnd-on-audio-input" type="b">
+      <default>false</default>
+      <description>Decides whether Do Not Disturb should be automatically switched on if an audio input is recording</description>
+    </key>
     <key name="dnd-on-screen-sharing" type="b">
       <default>true</default>
       <description>Decides whether Do Not Disturb should be automatically switched on while screen sharing</description>

--- a/src/notifiers/audio-input-notifier.ts
+++ b/src/notifiers/audio-input-notifier.ts
@@ -1,0 +1,28 @@
+import * as Main from "gnomejs://main.js";
+
+export class AudioInputNotifier {
+  subscribe(handler: (status: AudioInputStatus) => void): number {
+    return Main.panel.statusArea.quickSettings._volumeInput._input.connect(
+      "notify::visible",
+      () => {
+        const status = Main.panel.statusArea.quickSettings._volumeInput._input
+          .visible
+          ? AudioInputStatus.active
+          : AudioInputStatus.inactive;
+
+        handler(status);
+      }
+    );
+  }
+
+  unsubscribe(subscriptionId: number) {
+    Main.panel.statusArea.quickSettings._volumeInput._input.disconnect(
+      subscriptionId
+    );
+  }
+}
+
+export enum AudioInputStatus {
+  active,
+  inactive,
+}

--- a/src/notifiers/index.ts
+++ b/src/notifiers/index.ts
@@ -1,2 +1,3 @@
-export * from './screen-recording-notifier';
-export * from './screen-sharing-notifier';
+export * from "./screen-recording-notifier";
+export * from "./screen-sharing-notifier";
+export * from "./audio-input-notifier";

--- a/src/prefs.ts
+++ b/src/prefs.ts
@@ -19,6 +19,7 @@ export default class Preferences extends ExtensionPreferences {
 
     this.setupScreenRecording(settings, group);
     this.setupScreenSharing(settings, group);
+    this.setupAudioInput(settings, group);
 
     page.add(group);
     window.add(page);
@@ -65,6 +66,28 @@ export default class Preferences extends ExtensionPreferences {
 
     toggle.connect("state-set", (_, state) => {
       settings.setShouldDndOnScreenSharing(state);
+
+      return false;
+    });
+
+    row.add_suffix(toggle);
+    row.activatable_widget = toggle;
+
+    group.add(row);
+  }
+
+  setupAudioInput(settings: SettingsManager, group: Adw.PreferencesGroup) {
+    const row = new Adw.ActionRow({
+      title: "Audio Input",
+    });
+
+    const toggle = new Gtk.Switch({
+      active: settings.getShouldDndOnAudioInput(),
+      valign: Gtk.Align.CENTER,
+    });
+
+    toggle.connect("state-set", (_, state) => {
+      settings.setShouldDndOnAudioInput(state);
 
       return false;
     });

--- a/src/settings-manager.ts
+++ b/src/settings-manager.ts
@@ -5,9 +5,11 @@ export const SettingsPath =
 
 const DoNotDisturbOnScreenSharingSetting = "dnd-on-screen-sharing";
 const DoNotDisturbOnScreenRecordingSetting = "dnd-on-screen-recording";
+const DoNotDisturbOnAudioInputSetting = "dnd-on-audio-input";
 const IsWaylandSetting = "is-wayland";
 
 type AvailableSettings =
+  | "dnd-on-audio-input"
   | "dnd-on-screen-sharing"
   | "dnd-on-screen-recording"
   | "is-wayland";
@@ -33,6 +35,14 @@ export class SettingsManager {
 
   setShouldDndOnScreenRecording(value: boolean) {
     this.settings.set_boolean(DoNotDisturbOnScreenRecordingSetting, value);
+  }
+
+  getShouldDndOnAudioInput(): boolean {
+    return this.settings.get_boolean(DoNotDisturbOnAudioInputSetting);
+  }
+
+  setShouldDndOnAudioInput(value: boolean) {
+    this.settings.set_boolean(DoNotDisturbOnAudioInputSetting, value);
   }
 
   getIsWayland(): boolean {


### PR DESCRIPTION
This will be useful both on Wayland, giving another way to detect that a meeting is in progress, and will make the extension usable on X11.