### PR TITLE
No dnd off if manually activated

### DIFF
--- a/resources/schemas/org.gnome.shell.extensions.do-not-disturb-while-screen-sharing-or-recording.gschema.xml
+++ b/resources/schemas/org.gnome.shell.extensions.do-not-disturb-while-screen-sharing-or-recording.gschema.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <schemalist>
-  <schema id="org.gnome.shell.extensions.do-not-disturb-while-screen-sharing-or-recording" 
+  <schema id="org.gnome.shell.extensions.do-not-disturb-while-screen-sharing-or-recording"
           path="/org/gnome/shell/extensions/do-not-disturb-while-screen-sharing-or-recording/">
     <!-- See also: https://docs.gtk.org/glib/gvariant-format-strings.html -->
     <key name="dnd-on-screen-sharing" type="b">
@@ -14,6 +14,10 @@
     <key name="is-wayland" type="b">
       <default>true</default>
       <description>Internal state informing prefs if Wayland session is running</description>
+    </key>
+    <key name="was-dnd-active" type="b">
+      <default>false</default>
+      <description>DND status when the automatic DND was activated (internal state)</description>
     </key>
   </schema>
 </schemalist>

--- a/src/dnd-manager.ts
+++ b/src/dnd-manager.ts
@@ -1,28 +1,30 @@
 import Gio from "@gi-ts/gio2";
 
 const showBannersSetting = "show-banners";
-const schemaId = "org.gnome.desktop.notifications";
+const notificationsSchemaId = "org.gnome.desktop.notifications";
 
 export class DoNotDisturbManager {
-  private _settings: Gio.Settings | null = null;
+  private _notificationsSettings: Gio.Settings | null = null;
 
-  private getSettings() {
-    if (!this._settings) {
-      this._settings = new Gio.Settings({ schema_id: schemaId });
+  private getNotificationsSettings() {
+    if (!this._notificationsSettings) {
+      this._notificationsSettings = new Gio.Settings({
+        schema_id: notificationsSchemaId,
+      });
     }
 
-    return this._settings;
+    return this._notificationsSettings;
   }
 
   turnDndOn() {
-    this.getSettings().set_boolean(showBannersSetting, false);
+    this.getNotificationsSettings().set_boolean(showBannersSetting, false);
   }
 
   turnDndOff() {
-    this.getSettings().set_boolean(showBannersSetting, true);
+    this.getNotificationsSettings().set_boolean(showBannersSetting, true);
   }
 
   dispose() {
-    this._settings = null;
+    this._notificationsSettings = null;
   }
 }

--- a/src/dnd-manager.ts
+++ b/src/dnd-manager.ts
@@ -1,10 +1,16 @@
 import Gio from "@gi-ts/gio2";
+import { SettingsManager } from "settings-manager";
 
 const showBannersSetting = "show-banners";
 const notificationsSchemaId = "org.gnome.desktop.notifications";
 
 export class DoNotDisturbManager {
   private _notificationsSettings: Gio.Settings | null = null;
+  private _settingsManager: SettingsManager | null = null;
+
+  constructor(settingsManager: SettingsManager) {
+    this._settingsManager = settingsManager;
+  }
 
   private getNotificationsSettings() {
     if (!this._notificationsSettings) {
@@ -17,11 +23,16 @@ export class DoNotDisturbManager {
   }
 
   turnDndOn() {
+    this._settingsManager?.setWasDoNotDisturbActive(
+      !this.getNotificationsSettings().get_boolean(showBannersSetting)
+    );
     this.getNotificationsSettings().set_boolean(showBannersSetting, false);
   }
 
   turnDndOff() {
-    this.getNotificationsSettings().set_boolean(showBannersSetting, true);
+    if (!this._settingsManager?.getWasDoNotDisturbActive()) {
+      this.getNotificationsSettings().set_boolean(showBannersSetting, true);
+    }
   }
 
   dispose() {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -3,7 +3,12 @@ import { Extension } from "gnomejs://extension.js";
 import Meta from "@gi-types/meta10";
 
 import { DoNotDisturbManager } from "dnd-manager";
-import { ScreenRecordingNotifier, ScreenRecordingStatus, ScreenSharingNotifier, ScreenSharingStatus } from "./notifiers";
+import {
+  ScreenRecordingNotifier,
+  ScreenRecordingStatus,
+  ScreenSharingNotifier,
+  ScreenSharingStatus,
+} from "./notifiers";
 import { SettingsManager, SettingsPath } from "settings-manager";
 
 export default class DoNotDisturbWhileScreenSharingOrRecordingExtension extends Extension {
@@ -24,7 +29,7 @@ export default class DoNotDisturbWhileScreenSharingOrRecordingExtension extends 
 
     this._screenRecordingNotifier = new ScreenRecordingNotifier();
     this._screenSharingNotifier = new ScreenSharingNotifier();
-    this._dndManager = new DoNotDisturbManager();
+    this._dndManager = new DoNotDisturbManager(this._settings);
 
     this._screenRecordingSubId = this._screenRecordingNotifier.subscribe(
       this.handleScreenRecording.bind(this)

--- a/src/settings-manager.ts
+++ b/src/settings-manager.ts
@@ -6,11 +6,13 @@ export const SettingsPath =
 const DoNotDisturbOnScreenSharingSetting = "dnd-on-screen-sharing";
 const DoNotDisturbOnScreenRecordingSetting = "dnd-on-screen-recording";
 const IsWaylandSetting = "is-wayland";
+const WasDoNotDisturbActiveSetting = "was-dnd-active";
 
 type AvailableSettings =
   | "dnd-on-screen-sharing"
   | "dnd-on-screen-recording"
-  | "is-wayland";
+  | "is-wayland"
+  | "was-dnd-active";
 
 export class SettingsManager {
   private settings: Gio.Settings;
@@ -41,6 +43,14 @@ export class SettingsManager {
 
   setIsWayland(value: boolean) {
     this.settings.set_boolean(IsWaylandSetting, value);
+  }
+
+  getWasDoNotDisturbActive(): boolean {
+    return this.settings.get_boolean(WasDoNotDisturbActiveSetting);
+  }
+
+  setWasDoNotDisturbActive(value: boolean) {
+    this.settings.set_boolean(WasDoNotDisturbActiveSetting, value);
   }
 
   connectToChanges(settingName: AvailableSettings, func: () => void): number {


### PR DESCRIPTION
If a user already has DND activated before a screen share or recording starts, do not turn it off when the session ends.

Note that this trivially conflicts with PR #3.