### PR TITLE
Update for Gnome 50

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,10 +14,6 @@ Do Not Disturb mode stops notifications from appearing on your screen to let you
 focus on your work. Notifications may contain sensitive content that you might
 not want to show to everyone while you're screen-sharing.
 
-Note that screen sharing will toogle "Do Not Disturb" only on Wayland sessions.
-X11 is not supported! However, screen recording toggle will work on both Wayland
-and X11.
-
 It is likely that not all screen recording apps will trigger the extension to do
 its job. The extension was tested with the Gnome built-in screen recorder.
 
@@ -56,5 +52,4 @@ Manager](https://flathub.org/apps/com.mattjakeman.ExtensionManager)).
 Anytime you change anything, rebuild the extension with `npm run build`, and
 restart the session:
 
-- on Wayland, log out and log in (I know, it's painful),
-- on X11, open "Run a Command" dialog (Alt + F2), type "r" and press Enter
+- on Wayland, log out and log in (I know, it's painful)

--- a/resources/metadata.json
+++ b/resources/metadata.json
@@ -1,8 +1,8 @@
 {
   "name": "Do Not Disturb While Screen Sharing Or Recording",
-  "description": "Automatically switches on the \"Do Not Disturb\" mode while screen sharing or screen recording. As soon as screen sharing/recording is over, \"Do Not Disturb\" mode will be switched back off.\nDo Not Disturb mode stops notifications from appearing on your screen to let you focus on your work. Notifications may contain sensitive content that you might not want to show to everyone while you're screen-sharing.\nNote that screen sharing will toogle \"Do Not Disturb\" only on Wayland sessions. X11 is not supported! However, screen recording toggle will work on both Wayland and X11.\nIt is likely that not all screen recording apps will trigger the extension to do its job. The extension was tested with the Gnome built-in screen recorder.",
+  "description": "Automatically switches on the \"Do Not Disturb\" mode while screen sharing or screen recording. As soon as screen sharing/recording is over, \"Do Not Disturb\" mode will be switched back off.\nDo Not Disturb mode stops notifications from appearing on your screen to let you focus on your work. Notifications may contain sensitive content that you might not want to show to everyone while you're screen-sharing.\nIt is likely that not all screen recording apps will trigger the extension to do its job. The extension was tested with the Gnome built-in screen recorder.",
   "uuid": "do-not-disturb-while-screen-sharing-or-recording@marcinjahn.com",
-  "shell-version": ["47", "48", "49"],
+  "shell-version": ["50"],
   "url": "https://github.com/marcinjahn/gnome-do-not-disturb-while-screen-sharing-or-recording-extension",
-  "version": 6
+  "version": 7
 }

--- a/resources/schemas/org.gnome.shell.extensions.do-not-disturb-while-screen-sharing-or-recording.gschema.xml
+++ b/resources/schemas/org.gnome.shell.extensions.do-not-disturb-while-screen-sharing-or-recording.gschema.xml
@@ -11,9 +11,5 @@
       <default>true</default>
       <description>Decides whether Do Not Disturb should be automatically switched on while screen recording</description>
     </key>
-    <key name="is-wayland" type="b">
-      <default>true</default>
-      <description>Internal state informing prefs if Wayland session is running</description>
-    </key>
   </schema>
 </schemalist>

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,9 +1,12 @@
 import { Extension } from "gnomejs://extension.js";
 
-import Meta from "@gi-types/meta10";
-
 import { DoNotDisturbManager } from "dnd-manager";
-import { ScreenRecordingNotifier, ScreenRecordingStatus, ScreenSharingNotifier, ScreenSharingStatus } from "./notifiers";
+import {
+  ScreenRecordingNotifier,
+  ScreenRecordingStatus,
+  ScreenSharingNotifier,
+  ScreenSharingStatus,
+} from "./notifiers";
 import { SettingsManager, SettingsPath } from "settings-manager";
 
 export default class DoNotDisturbWhileScreenSharingOrRecordingExtension extends Extension {
@@ -20,8 +23,6 @@ export default class DoNotDisturbWhileScreenSharingOrRecordingExtension extends 
 
     this._settings = new SettingsManager(this.getSettings(SettingsPath));
 
-    this.checkCompositor();
-
     this._screenRecordingNotifier = new ScreenRecordingNotifier();
     this._screenSharingNotifier = new ScreenSharingNotifier();
     this._dndManager = new DoNotDisturbManager();
@@ -33,14 +34,6 @@ export default class DoNotDisturbWhileScreenSharingOrRecordingExtension extends 
     this._screenSharingSubId = this._screenSharingNotifier.subscribe(
       this.handleScreenSharing.bind(this)
     );
-  }
-
-  private checkCompositor() {
-    if (!Meta.is_wayland_compositor()) {
-      this._settings?.setIsWayland(false);
-    } else {
-      this._settings?.setIsWayland(true);
-    }
   }
 
   private handleScreenSharing(status: ScreenSharingStatus) {

--- a/src/notifiers/screen-sharing-notifier.ts
+++ b/src/notifiers/screen-sharing-notifier.ts
@@ -1,18 +1,9 @@
-import Meta from "@gi-types/meta10";
-
 export class ScreenSharingNotifier {
   private _handlesCount: number;
   private _handles: Map<number, Handle> = new Map<number, Handle>();
   private _controller: any;
 
   subscribe(handler: (status: ScreenSharingStatus) => void): number | null {
-    if (!Meta.is_wayland_compositor()) {
-      console.warn(
-        '"Do Not Disturb While Screen Sharing or Recording" extension does not support compositors other than Wayland. Subscription will not be created. If you\'re using X11 exlusively, disable or remove this extension since it will not work anyway.'
-      );
-      return null;
-    }
-
     this._controller = global.backend.get_remote_access_controller();
 
     if (!this._controller) {

--- a/src/prefs.ts
+++ b/src/prefs.ts
@@ -47,20 +47,13 @@ export default class Preferences extends ExtensionPreferences {
   }
 
   setupScreenSharing(settings: SettingsManager, group: Adw.PreferencesGroup) {
-    const isWayland = settings.getIsWayland();
-
     const row = new Adw.ActionRow({
       title: "Screen Sharing",
-      subtitle: !isWayland
-        ? "Disabled, since it works only on Wayland sessions, and you are running X11"
-        : "",
-      sensitive: isWayland,
     });
 
     const toggle = new Gtk.Switch({
-      active: isWayland ? settings.getShouldDndOnScreenSharing() : false,
+      active: settings.getShouldDndOnScreenSharing(),
       valign: Gtk.Align.CENTER,
-      sensitive: isWayland,
     });
 
     toggle.connect("state-set", (_, state) => {

--- a/src/settings-manager.ts
+++ b/src/settings-manager.ts
@@ -5,12 +5,8 @@ export const SettingsPath =
 
 const DoNotDisturbOnScreenSharingSetting = "dnd-on-screen-sharing";
 const DoNotDisturbOnScreenRecordingSetting = "dnd-on-screen-recording";
-const IsWaylandSetting = "is-wayland";
 
-type AvailableSettings =
-  | "dnd-on-screen-sharing"
-  | "dnd-on-screen-recording"
-  | "is-wayland";
+type AvailableSettings = "dnd-on-screen-sharing" | "dnd-on-screen-recording";
 
 export class SettingsManager {
   private settings: Gio.Settings;
@@ -33,14 +29,6 @@ export class SettingsManager {
 
   setShouldDndOnScreenRecording(value: boolean) {
     this.settings.set_boolean(DoNotDisturbOnScreenRecordingSetting, value);
-  }
-
-  getIsWayland(): boolean {
-    return this.settings.get_boolean(IsWaylandSetting);
-  }
-
-  setIsWayland(value: boolean) {
-    this.settings.set_boolean(IsWaylandSetting, value);
   }
 
   connectToChanges(settingName: AvailableSettings, func: () => void): number {


### PR DESCRIPTION
The `Meta.is_wayland_compositor` API has been removed in Gnome 50 along with the rest of the X11 backend, which breaks the extension at initialization. Since X11 is no longer supported, the compositor check is not needed anymore.

This PR removes all compositor-related code and bumps the supported Gnome version to 50.

Manually tested on Arch Linux with Gnome 50:
- Screen sharing via the desktop Discord app and via Discord and Google Meet in the browser.
- Screen recording via the built-in Gnome screen recorder.

Fixes #8 